### PR TITLE
Adding CellML 2.0

### DIFF
--- a/specifications/cellml.2.0.md
+++ b/specifications/cellml.2.0.md
@@ -1,0 +1,12 @@
+# CellML 2.0
+![CellML logo](./files/cellml-logo.png) 
+
+CellML 2.0 has been frozen on 17 April 2020.
+
+The specification can be found at: http://www.cellml.org/specifications/cellml_2.0
+
+Identifier for this specification is: http://identifiers.org/combine.specifications/cellml.2.0
+
+To cite this document, please use:
+
+Michael Clerx, Michael T. Cooling, Jonathan Cooper, Alan Garny, Keri Moyle, David P. Nickerson, Poul Nielsen, Hugh Sorby. CellML 2.0 Specification. Available from COMBINE http://identifiers.org/combine.specifications/cellml.2.0 (2020)

--- a/specifications/cellml.md
+++ b/specifications/cellml.md
@@ -9,6 +9,7 @@ CellML is defined in a set of specification documents that describe the elements
 
 The specifications are:
 
+* [CellML 2.0](cellml.2.0.md): http://identifiers.org/combine.specifications/cellml.2.0
 * [CellML 1.1](cellml.1.1.md): http://identifiers.org/combine.specifications/cellml.1.1
 * [CellML 1.0](cellml.1.0.md): http://identifiers.org/combine.specifications/cellml.1.0
 
@@ -22,7 +23,7 @@ CellML development is discussed on the mailing list [cellml-discussion@cellml.or
 
 ## Software support
 
-There are some [tools, APIs, and libraries available](http://www.cellml.org/tools) which support the CellML format. An extensive [[http://models.cellml.org|repository of models]] is also available.
+There are some [tools, APIs, and libraries available](http://www.cellml.org/tools) which support the CellML format. An extensive [[https://models.physiomeproject.org|repository of models]] is also available.
 
 ## Contact
 


### PR DESCRIPTION
Adding the CellML 2.0 spec and corresponding updates for the main CellML page. Fixes #7 