### PR TITLE
Correct OMEX Metadata identifiers.org URIs

### DIFF
--- a/specifications/omex-metadata.md
+++ b/specifications/omex-metadata.md
@@ -9,8 +9,8 @@ A standardized approach to annotating computational biomedical models and their 
 OMEX metadata is defined in a set of specification documents that describe the elements of the language and its syntax.
 
 The latest specifications are available here:
-* [OMEX metadata 1.2](https://identifiers.org/combine.specifications:omex-metadata-1.2)
-* [OMEX metadata 1.0](https://identifiers.org/combine.specifications:omex-metadata-1.0)
+* OMEX metadata 1.2: https://identifiers.org/combine.specifications:omex-metadata.1.2
+* OMEX metadata 1.0: https://identifiers.org/combine.specifications:omex-metadata.1.0
 
 ## Communication
 OMEX Metadata development is discussed on the combine-annot mailing list at https://groups.google.com/forum/#!forum/combine-annot.


### PR DESCRIPTION
Correct the URIs so that they resolve and list them out explicitly to make it clearer what URIs to use.